### PR TITLE
Upgrade to ProMotion 2.0.0.rc3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,20 @@
 GIT
   remote: https://github.com/clearsightstudio/ProMotion.git
-  revision: 40d1f0dfc5d5cb3a43b61b4d02d6c4c9376c1507
+  revision: 4957d946af37caddd2ae3de7c5daf815416a35af
   branch: pm2
   specs:
-    ProMotion (2.0.0)
-      dbt (~> 1.1.4)
-      methadone (~> 1.3)
+    ProMotion (2.0.0.rc3)
+      methadone (~> 1.4)
 
 PATH
   remote: .
   specs:
     ProMotion-push (0.1.0)
-      ProMotion (~> 2.0.0)
+      ProMotion (~> 2.0.0.rc3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    dbt (1.1.4)
     methadone (1.4.0)
       bundler
     motion-redgreen (0.1.0)

--- a/ProMotion-push.gemspec
+++ b/ProMotion-push.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ProMotion", "~> 2.0.0"
+  spec.add_dependency "ProMotion", "~> 2.0.0.rc3"
   spec.add_development_dependency "motion-stump", "~> 0.3"
   spec.add_development_dependency "motion-redgreen", "~> 0.1"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
ProMotion push doesn't work against the current git branch because of the rc3 version change
